### PR TITLE
feat: Distribute "idc_index.csv.zip" within the wheel

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,8 +45,3 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release' && github.event.action == 'published'
-        with:
-          # Remember to tell (test-)pypi about this repo before publishing
-          # Remove this line to publish to PyPI
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           python -m pytest -ra --cov --cov-report=xml --cov-report=term
           --durations=20
 
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v4.1.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+#      - name: Upload coverage report
+#        uses: codecov/codecov-action@v4.1.0
+#        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,12 @@ repos:
         args: []
         additional_dependencies:
           - pytest
+          # Since the "python_version" set in the "tool.mypy" section of "pyproject.toml" is "3.8",
+          # we ensure type checking also works when running the hook from Python versions above 3.8 by always
+          # installing "importlib_metadata". Note that because the "importlib.metadata.distribution"
+          # module was added in Python version 3.10 and later, this line can be removed when only supporting
+          # Python versions 3.10 and above.
+          - importlib_metadata>=2.0
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.6"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.15...3.26)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES NONE)
+
+
+set(idc_index_release_version "0.3.2")
+set(idc_index_data_url "https://github.com/ImagingDataCommons/idc-index/releases/download/${idc_index_release_version}/idc_index.csv.zip")
+set(idc_index_data_sha256 "70ec9f915686a27bee3098163b8695c69c8696c05bfb7bd76943a24024cdeeb9")
+
+#
+# Download and install index
+#
+set(download_dir "${PROJECT_BINARY_DIR}")
+include(FetchContent)
+FetchContent_Populate(s5cmd
+  URL ${idc_index_data_url}
+  URL_HASH SHA256=${idc_index_data_sha256}
+  DOWNLOAD_DIR ${download_dir}
+  DOWNLOAD_NO_EXTRACT TRUE
+  )
+install(FILES "${download_dir}/idc_index.csv.zip" DESTINATION "idc_index_data")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
-build-backend = "hatchling.build"
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
 
 
 [project]
@@ -32,7 +32,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = []
+dependencies = ["importlib_metadata>=2.0; python_version<'3.10'"]
 
 [project.optional-dependencies]
 test = [
@@ -58,13 +58,17 @@ Discussions = "https://discourse.canceridc.dev/"
 Changelog = "https://github.com/ImagingDataCommons/idc-index-data/releases"
 
 
-[tool.hatch]
-version.source = "vcs"
-build.hooks.vcs.version-file = "src/idc_index_data/_version.py"
+[tool.scikit-build]
+minimum-version = "0.8.2"
+build-dir = "build/{wheel_tag}"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["src/idc_index_data/_version.py"]
+wheel.platlib = false
+wheel.py-api = "py3"
 
-[tool.hatch.envs.default]
-features = ["test"]
-scripts.test = "pytest {args}"
+
+[tool.setuptools_scm]
+write_to = "src/idc_index_data/_version.py"
 
 
 [tool.pytest.ini_options]

--- a/src/idc_index_data/__init__.py
+++ b/src/idc_index_data/__init__.py
@@ -6,6 +6,28 @@ idc-index-data: ImagingDataCommons index to query and download data.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import distribution
+else:
+    from importlib_metadata import distribution
+
 from ._version import version as __version__
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "IDC_INDEX_CSV_ARCHIVE_FILEPATH"]
+
+
+def _lookup(path: str) -> Path:
+    """Support editable installation by looking up path using distribution API."""
+    files = distribution("idc_index_data").files
+    if files is not None:
+        for _file in files:
+            if str(_file) == path:
+                return Path(str(_file.locate())).resolve(strict=True)
+    msg = f"Failed to lookup '{path}`."
+    raise FileNotFoundError(msg)
+
+
+IDC_INDEX_CSV_ARCHIVE_FILEPATH: Path = _lookup("idc_index_data/idc_index.csv.zip")

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -7,3 +7,8 @@ import idc_index_data as m
 
 def test_version():
     assert importlib.metadata.version("idc_index_data") == m.__version__
+
+
+def test_filepath():
+    assert m.IDC_INDEX_CSV_ARCHIVE_FILEPATH.is_file()
+    assert m.IDC_INDEX_CSV_ARCHIVE_FILEPATH.name == "idc_index.csv.zip"


### PR DESCRIPTION
Switch the build-backend from "hatchling" to "scikit-build-core" to leverage CMake as scripting language while building a pure Python wheel.

Disable submission of coverage reports as the project is not explicitly registered.