### PR TITLE
fix: remove placeholder branch as it is no longer needed

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: "keep-alive"
       - uses: gautamkrishnar/keepalive-workflow@v2
         with:
           time_elapsed: 50


### PR DESCRIPTION
Previously we were creating a dummy commit to keep-alive branch. However with GitHub's new API endpoint to enable github actions, there is no longer a need to commit at all. v2 of the gha started using the GitHub's new API endpoint.