### PR TITLE
CI: update workflow to pull_request_target

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main


### PR DESCRIPTION
Current pull_request does not allow PRs from forks to have access to the repo secrets.

See details in https://securitylab.github.com/research/github-actions-preventing-pwn-requests/