### PR TITLE
ci: Ensure testing of proposed code in pull requests from forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
This commit reverts the changes introduced in commit 4aa6655b9, which modified the CI workflow to use `pull_request_target` for accessing repository secrets during pull request testing.

Originally, the intention was to grant access to repository secrets within the pull request environment. However, using `pull_request_target` caused the workflow to run against the base branch instead of the proposed changes in the pull request.

To maintain secure code review practices and avoid insecure workarounds, this commit restores the previous workflow behavior. A subsequent commit will address this issue by updating the workflow to detect secret unavailability and prompt developers to request write access to the project instead.