### PR TITLE
Remove unneeded importlib metadata dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,12 +54,6 @@ repos:
         args: []
         additional_dependencies:
           - pytest
-          # Since the "python_version" set in the "tool.mypy" section of "pyproject.toml" is "3.8",
-          # we ensure type checking also works when running the hook from Python versions above 3.8 by always
-          # installing "importlib_metadata". Note that because the "importlib.metadata.distribution"
-          # module was added in Python version 3.10 and later, this line can be removed when only supporting
-          # Python versions 3.10 and above.
-          - importlib_metadata>=2.0
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["importlib_metadata>=2.0; python_version<'3.10'"]
+dependencies = []
 
 [project.optional-dependencies]
 test = [

--- a/src/idc_index_data/__init__.py
+++ b/src/idc_index_data/__init__.py
@@ -6,13 +6,8 @@ idc-index-data: ImagingDataCommons index to query and download data.
 
 from __future__ import annotations
 
-import sys
+from importlib.metadata import distribution
 from pathlib import Path
-
-if sys.version_info >= (3, 10):
-    from importlib.metadata import distribution
-else:
-    from importlib_metadata import distribution
 
 from ._version import version as __version__
 

--- a/src/idc_index_data/__init__.py
+++ b/src/idc_index_data/__init__.py
@@ -19,7 +19,7 @@ from ._version import version as __version__
 __all__ = [
     "__version__",
     "IDC_INDEX_CSV_ARCHIVE_FILEPATH",
-    # "IDC_INDEX_PARQUET_FILEPATH",
+    "IDC_INDEX_PARQUET_FILEPATH",
 ]
 
 


### PR DESCRIPTION
Remove unneeded importlib_metadata dependency with Python < 3.10 

It turns out that the `importlib.metadata.distribution()` function is available in Python 3.8 and 3.9 where it is implemented in `Lib/importlib/metadata.py` and not `Lib/importlib/metadata/__init__.py`.

For more details:
* https://github.com/scikit-build/cmake-python-distributions/pull/474#discussion_r1539553024