### PR TITLE
Revisit versioning and streamline maintenance adding "bump" and "tag_release" nox sessions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -112,3 +112,11 @@ nox -s bump -- <version>
 
 And follow the instructions it gives you. Leave off the version to bump to the
 latest version. Add `-–commit` to run the commit procedure.
+
+# Tagging a release
+
+You can print the instructions for tagging a release using:
+
+```bash
+nox -s tag_release
+```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,3 +99,16 @@ pre-commit run -a
 ```
 
 to check all files.
+
+# Updating the IDC index version
+
+You can update the version using:
+
+```bash
+export GCP_PROJECT=idc-external-025
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile.json
+nox -s bump -- <version>
+```
+
+And follow the instructions it gives you. Leave off the version to bump to the
+latest version. Add `-–commit` to run the commit procedure.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 from pathlib import Path
 
@@ -187,3 +188,18 @@ def bump(session: nox.Session) -> None:
         "scripts/python/update_idc_index_version.py",
         files,
     )
+
+
+@nox.session(venv_backend="none")
+def tag_release(session: nox.Session) -> None:
+    """
+    Print instructions for tagging a release and pushing it to GitHub.
+    """
+
+    session.log("Run the following commands to make a release:")
+    txt = Path("pyproject.toml").read_text()
+    current_version = next(iter(re.finditer(r'^version = "([\d\.]+)$"', txt))).group(1)
+    print(
+        f"git tag --sign -m 'idc-index-data {current_version}' {current_version} main"
+    )
+    print(f"git push origin {current_version}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "idc-index-data"
+version = "17.0.0"
 authors = [
   { name = "Andrey Fedorov", email = "andrey.fedorov@gmail.com" },
   { name = "Vamsi Thiriveedhi", email = "vthiriveedhi@mgh.harvard.edu" },
@@ -39,7 +40,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dynamic = ["version"]
 dependencies = []
 
 [project.optional-dependencies]
@@ -69,15 +69,15 @@ Changelog = "https://github.com/ImagingDataCommons/idc-index-data/releases"
 [tool.scikit-build]
 minimum-version = "0.8.2"
 build-dir = "build/{wheel_tag}"
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["src/idc_index_data/_version.py"]
 wheel.platlib = false
 wheel.py-api = "py3"
 
 
-[tool.setuptools_scm]
-write_to = "src/idc_index_data/_version.py"
-version_scheme = "no-guess-dev"
+[[tool.scikit-build.generate]]
+path = "idc_index_data/_version.py"
+template = '''
+version = "${version}"
+'''
 
 
 [tool.pytest.ini_options]

--- a/scripts/python/update_idc_index_version.py
+++ b/scripts/python/update_idc_index_version.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Command line executable allowing to update source files given a IDC index version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import re
+import textwrap
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent / "../.."
+
+
+@contextlib.contextmanager
+def _log(txt, verbose=True):
+    if verbose:
+        print(txt)  # noqa: T201
+    yield
+    if verbose:
+        print(f"{txt} - done")  # noqa: T201
+
+
+def _update_file(filepath, regex, replacement):
+    msg = "Updating %s" % os.path.relpath(str(filepath), ROOT_DIR)
+    with _log(msg):
+        pattern = re.compile(regex)
+        with filepath.open() as doc_file:
+            lines = doc_file.readlines()
+            updated_content = []
+            for line in lines:
+                updated_content.append(re.sub(pattern, replacement, line))
+        with filepath.open("w") as doc_file:
+            doc_file.writelines(updated_content)
+
+
+def update_pyproject_toml(idc_index_version):
+    pattern = re.compile(r'^version = "[\w\.]+"$')
+    replacement = f'version = "{idc_index_version}.0.0"'
+    _update_file(ROOT_DIR / "pyproject.toml", pattern, replacement)
+
+
+def update_sql_scripts(idc_index_version):
+    pattern = re.compile(r"idc_v\d+")
+    replacement = f"idc_v{idc_index_version}"
+    _update_file(ROOT_DIR / "scripts/sql/idc_index.sql", pattern, replacement)
+
+
+def update_tests(idc_index_version):
+    pattern = re.compile(r"EXPECTED_IDC_INDEX_VERSION = \d+")
+    replacement = f"EXPECTED_IDC_INDEX_VERSION = {idc_index_version}"
+    _update_file(ROOT_DIR / "tests/test_package.py", pattern, replacement)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "idc_index_version",
+        metavar="IDC_INDEX_VERSION",
+        type=int,
+        help="IDC index version of the form NN",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Hide the output",
+    )
+
+    args = parser.parse_args()
+
+    update_pyproject_toml(args.idc_index_version)
+    update_sql_scripts(args.idc_index_version)
+    update_tests(args.idc_index_version)
+
+    if not args.quiet:
+        msg = """\
+            Complete! Now run:
+
+            git switch -c update-to-idc-index-{release}
+            git add -u pyproject.toml scripts/sql/idc_index.sql tests/test_package.py
+            git commit -m "Update to IDC index {release}"
+            gh pr create --fill --body "Created by update_idc_index_version.py"
+            """
+        print(textwrap.dedent(msg.format(release=args.idc_index_version)))  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/src/idc_index_data/_version.pyi
+++ b/src/idc_index_data/_version.pyi
@@ -1,4 +1,3 @@
 from __future__ import annotations
 
 version: str
-version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 import importlib.metadata
 
+from packaging.version import Version
+
 import idc_index_data as m
+
+EXPECTED_IDC_INDEX_VERSION = 17
 
 
 def test_version():
     assert importlib.metadata.version("idc_index_data") == m.__version__
+
+
+def test_idc_index_version():
+    assert Version(m.__version__).major == EXPECTED_IDC_INDEX_VERSION
 
 
 def test_filepath():


### PR DESCRIPTION
Revisit versioning by hard-coding the IDC index version as the major version specified in the `pyproject.toml` file.

Add nox sessions:
- `bump`: for updating the sources by querying the latest IDC index version
- `tag_release`: for displaying instructions for tagging a release

Adapted from https://github.com/scikit-build/cmake-python-distributions/pull/470 by @henryiii

Once this is integrated, it will be trivial to setup a scheduled workflow for creating a pull request if a new version of the IDC table is available.

Related issues:
* https://github.com/ImagingDataCommons/idc-index-data/issues/2