### PR TITLE
Switch index from CSV format to parquet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ if(NOT DEFINED ENV{GCP_PROJECT})
   message(FATAL_ERROR "GCP_PROJECT env. variable is not set")
 endif()
 
-option(IDC_INDEX_DATA_GENERATE_CSV_ARCHIVE "Generate idc_index.csv.zip file" ON)
-option(IDC_INDEX_DATA_GENERATE_PARQUET "Generate idc_index.parquet file" OFF)
+option(IDC_INDEX_DATA_GENERATE_CSV_ARCHIVE "Generate idc_index.csv.zip file" OFF)
+option(IDC_INDEX_DATA_GENERATE_PARQUET "Generate idc_index.parquet file" ON)
 
 set(download_dir "${PROJECT_BINARY_DIR}")
 

--- a/scripts/python/idc_index_data_manager.py
+++ b/scripts/python/idc_index_data_manager.py
@@ -66,7 +66,7 @@ class IDCIndexDataManager:
 
             if generate_parquet:
                 parquet_file_name = f"{output_basename}.parquet"
-                index_df.to_parquet(parquet_file_name)
+                index_df.to_parquet(parquet_file_name, compression="zstd")
                 logger.debug("Created Parquet file: %s", parquet_file_name)
 
     def retrieve_latest_idc_release_version(self) -> int:

--- a/src/idc_index_data/__init__.py
+++ b/src/idc_index_data/__init__.py
@@ -33,8 +33,6 @@ def _lookup(path: str, optional: bool = False) -> Path | None:
 
 
 IDC_INDEX_CSV_ARCHIVE_FILEPATH: Path | None = _lookup(
-    "idc_index_data/idc_index.csv.zip"
+    "idc_index_data/idc_index.csv.zip", optional=True
 )
-IDC_INDEX_PARQUET_FILEPATH: Path | None = _lookup(
-    "idc_index_data/idc_index.parquet", optional=True
-)
+IDC_INDEX_PARQUET_FILEPATH: Path | None = _lookup("idc_index_data/idc_index.parquet")


### PR DESCRIPTION
parquet offers several advantages over csv particularly when used in combination with duckdb.

duckdb can query directly against parquet instead of having to load the entire file into a dataframe. This is useful as only the required columns are loaded into memory instead of all, as done in csv/pandas combo.