### PR TITLE
enh: include analysis_result_id column

### DIFF
--- a/scripts/sql/idc_index.sql
+++ b/scripts/sql/idc_index.sql
@@ -1,6 +1,7 @@
 SELECT
   # collection level attributes
   ANY_VALUE(collection_id) AS collection_id,
+  ANY_VALUE(analysis_result_id) AS analysis_result_id,
   ANY_VALUE(PatientID) AS PatientID,
   SeriesInstanceUID,
   ANY_VALUE(StudyInstanceUID) AS StudyInstanceUID,


### PR DESCRIPTION
This attribute is essential for separating and describing analysis results included in IDC.