### PR TITLE
enh: add sm_index query

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,3 @@
+This folder contains SQL scripts that are used to generate tables that are
+attached to the releases as assets. Initially, those will be generated and
+attached manually, but in the future this process may be automated.

--- a/assets/sm_index.sql
+++ b/assets/sm_index.sql
@@ -1,0 +1,6 @@
+SELECT
+  * EXCEPT(Modality)
+FROM
+  `bigquery-public-data.idc_v18.dicom_metadata_curated_series_level`
+WHERE
+  Modality = "SM"


### PR DESCRIPTION
Re #15

Adding query that replicates the content of the existing `bigquery-public-data.idc_v18.dicom_metadata_curated_series_level` BigQuery table (with the exception of the `Modality` column). This is non-controversial, since we have already discussed the content of that table, it already flattened, and it is sufficient to address the immediate needs of the team and should be sufficient to meet the needs of the user in https://discourse.canceridc.dev/t/metadata-information-for-pathology-images/595.