### PR TITLE
feat-generate-external-indices

### DIFF
--- a/.github/workflows/external-indices.yml
+++ b/.github/workflows/external-indices.yml
@@ -1,0 +1,60 @@
+name: CD-external-indices
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  dist:
+    name: CD-external-indices
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install db-dtypes google-cloud-bigquery pandas pyarrow
+
+      - name: Authorize Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Execute SQL Query and Generate Parquet Files
+        run: |
+          python scripts/python/external-indices.py
+        env:
+          PROJECT_ID: ${{ env.GCP_PROJECT }}
+
+      - name: Create Tagged Release
+        id: create_tagged_release
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "*.parquet"
+          allowUpdates: true
+          omitBodyDuringUpdate: true

--- a/scripts/python/external-indices.py
+++ b/scripts/python/external-indices.py
@@ -1,0 +1,26 @@
+# new_script.py
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from idc_index_data_manager import IDCIndexDataManager
+
+
+def main():
+    project_id = os.getenv("PROJECT_ID")
+    manager = IDCIndexDataManager(project_id=project_id)
+    scripts_dir = Path(__file__).resolve().parent.parent
+    assets_dir = scripts_dir.parent / "assets"
+
+    # Collecting all .sql files from sql_dir and assets_dir
+    sql_files = [f for f in os.listdir(assets_dir) if f.endswith(".sql")]
+
+    for file_name in sql_files:
+        file_path = assets_dir / file_name
+        index_df, output_basename = manager.execute_sql_query(file_path)
+        index_df.to_parquet(f"{output_basename}.parquet")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
For every query ending with .sql in assests folder, a parquet file is generated. Upon creating a release as you would normally do, this gha workfow will update the latest release by attaching the parquet files. i.e no additional maintenance is required to add these assets to the release.