### PR TITLE
ENH: add embedding, fixative and staining to sm_index

### DIFF
--- a/assets/sm_index.sql
+++ b/assets/sm_index.sql
@@ -95,8 +95,8 @@ SELECT
   SPLIT(illuminationType_code_str,":")[SAFE_OFFSET(2)] as illuminationType_CodeMeaning,
 FROM
   temp_table
-JOIN slide_embedding on temp_table.SeriesInstanceUID = slide_embedding.SeriesInstanceUID
-JOIN slide_fixative on temp_table.SeriesInstanceUID = slide_fixative.SeriesInstanceUID
-JOIN slide_staining on temp_table.SeriesInstanceUID = slide_staining.SeriesInstanceUID
+LEFT JOIN slide_embedding on temp_table.SeriesInstanceUID = slide_embedding.SeriesInstanceUID
+LEFT JOIN slide_fixative on temp_table.SeriesInstanceUID = slide_fixative.SeriesInstanceUID
+LEFT JOIN slide_staining on temp_table.SeriesInstanceUID = slide_staining.SeriesInstanceUID
 WHERE
   Modality = "SM"


### PR DESCRIPTION
Since there are multiple items within a series, the use of arrays becomes unavoidable - unless we switch to instance-level index for SM

Related to https://github.com/ImagingDataCommons/IDC-ProjectManagement/issues/1796.

@DanielaSchacherer please take a look!