### PR TITLE
ENH: include core indices in the github release package

### DIFF
--- a/.github/workflows/external-indices.yml
+++ b/.github/workflows/external-indices.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Execute SQL Query and Generate Parquet Files
         run: |
-          python scripts/python/external-indices.py
+          python scripts/python/generate-indices.py
         env:
           PROJECT_ID: ${{ env.GCP_PROJECT }}
 

--- a/scripts/python/generate-indices.py
+++ b/scripts/python/generate-indices.py
@@ -11,6 +11,7 @@ def main():
     project_id = os.getenv("PROJECT_ID")
     manager = IDCIndexDataManager(project_id=project_id)
     scripts_dir = Path(__file__).resolve().parent.parent
+
     assets_dir = scripts_dir.parent / "assets"
 
     # Collecting all .sql files from sql_dir and assets_dir
@@ -18,6 +19,15 @@ def main():
 
     for file_name in sql_files:
         file_path = assets_dir / file_name
+        index_df, output_basename = manager.execute_sql_query(file_path)
+        index_df.to_parquet(f"{output_basename}.parquet")
+
+    core_indices_dir = scripts_dir.parent / "scripts" / "sql"
+
+    sql_files = [f for f in os.listdir(core_indices_dir) if f.endswith(".sql")]
+
+    for file_name in sql_files:
+        file_path = core_indices_dir / file_name
         index_df, output_basename = manager.execute_sql_query(file_path)
         index_df.to_parquet(f"{output_basename}.parquet")
 


### PR DESCRIPTION
Since it is very convenient to be able to access the files for all indices in the same manner, no matter if it is core or external index.