### PR TITLE
enh: add ct_index, mr_index, and pt_index with modality-specific acquisition parameters

### DIFF
--- a/assets/ct_index.sql
+++ b/assets/ct_index.sql
@@ -1,0 +1,167 @@
+# table-description:
+# This table contains one row per CT Image Storage (SOPClassUID 1.2.840.10008.5.1.4.1.1.2)
+# DICOM series in IDC, capturing acquisition and reconstruction parameters
+# that are not included in the main idc_index table.
+# The index can be joined to idc_index on SeriesInstanceUID to combine
+# universal series metadata with CT-specific acquisition parameters.
+# For XRayTubeCurrent, Exposure, and ExposureTime — which vary across instances within
+# a series due to dose modulation — both min and max values are reported.
+# All other attributes are aggregated with ANY_VALUE (one representative instance).
+
+WITH ct_data AS (
+  SELECT
+    SeriesInstanceUID,
+    ANY_VALUE(ImageType) AS ImageType,
+    ANY_VALUE(SAFE_CAST(PixelSpacing[SAFE_OFFSET(0)] AS FLOAT64)) AS PixelSpacing_row_mm,
+    ANY_VALUE(SAFE_CAST(PixelSpacing[SAFE_OFFSET(1)] AS FLOAT64)) AS PixelSpacing_col_mm,
+    ANY_VALUE(`Rows`) AS `Rows`,
+    ANY_VALUE(`Columns`) AS `Columns`,
+    ANY_VALUE(SAFE_CAST(SliceThickness AS FLOAT64)) AS SliceThickness,
+    ANY_VALUE(SAFE_CAST(KVP AS FLOAT64)) AS KVP,
+    ANY_VALUE(ScanOptions) AS ScanOptions,
+    ANY_VALUE(ConvolutionKernel) AS ConvolutionKernel,
+    ANY_VALUE(SAFE_CAST(GantryDetectorTilt AS FLOAT64)) AS GantryDetectorTilt,
+    MIN(SAFE_CAST(XRayTubeCurrent AS FLOAT64)) AS XRayTubeCurrent_min,
+    MAX(SAFE_CAST(XRayTubeCurrent AS FLOAT64)) AS XRayTubeCurrent_max,
+    ANY_VALUE(FilterType) AS FilterType,
+    MIN(SAFE_CAST(Exposure AS FLOAT64)) AS Exposure_min,
+    MAX(SAFE_CAST(Exposure AS FLOAT64)) AS Exposure_max,
+    MIN(SAFE_CAST(ExposureTime AS FLOAT64)) AS ExposureTime_min,
+    MAX(SAFE_CAST(ExposureTime AS FLOAT64)) AS ExposureTime_max,
+    ANY_VALUE(SAFE_CAST(DataCollectionDiameter AS FLOAT64)) AS DataCollectionDiameter,
+    ANY_VALUE(SAFE_CAST(ReconstructionDiameter AS FLOAT64)) AS ReconstructionDiameter,
+    ANY_VALUE(SpiralPitchFactor) AS SpiralPitchFactor
+  FROM `bigquery-public-data.idc_v24.dicom_all`
+  WHERE SOPClassUID = '1.2.840.10008.5.1.4.1.1.2'
+  GROUP BY SeriesInstanceUID
+)
+SELECT
+  # description:
+  # DICOM SeriesInstanceUID — unique identifier of the CT series; use to join with idc_index
+  SeriesInstanceUID,
+
+  # description:
+  # image type values as defined in DICOM ImageType attribute
+  # (e.g., ORIGINAL/DERIVED, PRIMARY/SECONDARY, AXIAL/LOCALIZER);
+  # aggregated with ANY_VALUE — constant across instances within a series
+  ImageType,
+
+  # description:
+  # in-plane pixel spacing along the row direction in mm, derived from DICOM PixelSpacing[0];
+  # a subset of CT series have anisotropic spacing where this differs from PixelSpacing_col_mm;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelSpacing_row_mm,
+
+  # description:
+  # in-plane pixel spacing along the column direction in mm, derived from DICOM PixelSpacing[1];
+  # a subset of CT series have anisotropic spacing where this differs from PixelSpacing_row_mm;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelSpacing_col_mm,
+
+  # description:
+  # number of pixel rows per image slice as defined in DICOM Rows attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  `Rows`,
+
+  # description:
+  # number of pixel columns per image slice as defined in DICOM Columns attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  `Columns`,
+
+  # description:
+  # nominal reconstructed slice thickness in mm as defined in DICOM SliceThickness attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  SliceThickness,
+
+  # description:
+  # peak kilovoltage of the X-ray tube in kV as defined in DICOM KVP attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  KVP,
+
+  # description:
+  # acquisition scan options as defined in DICOM ScanOptions attribute
+  # (e.g., HELICAL MODE, AXIAL MODE, SCOUT MODE); may contain multiple values;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  ScanOptions,
+
+  # description:
+  # reconstruction convolution kernel as defined in DICOM ConvolutionKernel attribute;
+  # vendor-specific string (e.g., B30f, STANDARD, LUNG); may contain multiple values;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  ConvolutionKernel,
+
+  # description:
+  # nominal angle of the scanning gantry in degrees as defined in DICOM GantryDetectorTilt
+  # attribute; non-zero for gantry-tilted acquisitions;
+  # constant across instances — aggregated with ANY_VALUE
+  GantryDetectorTilt,
+
+  # description:
+  # minimum X-ray tube current in mA across all instances in the series,
+  # derived from DICOM XRayTubeCurrent attribute;
+  # equals XRayTubeCurrent_max for fixed-current acquisitions;
+  # lower than XRayTubeCurrent_max for dose-modulated acquisitions (MIN across all instances)
+  XRayTubeCurrent_min,
+
+  # description:
+  # maximum X-ray tube current in mA across all instances in the series,
+  # derived from DICOM XRayTubeCurrent attribute;
+  # equals XRayTubeCurrent_min for fixed-current acquisitions;
+  # higher than XRayTubeCurrent_min for dose-modulated acquisitions (MAX across all instances)
+  XRayTubeCurrent_max,
+
+  # description:
+  # type of filter used in the acquisition as defined in DICOM FilterType attribute
+  # (e.g., WEDGE, BUTTERFLY, FLAT);
+  # constant across instances — aggregated with ANY_VALUE
+  FilterType,
+
+  # description:
+  # minimum exposure in mAs across all instances in the series,
+  # derived from DICOM Exposure attribute;
+  # equals Exposure_max for fixed-exposure acquisitions;
+  # lower than Exposure_max for dose-modulated acquisitions (MIN across all instances)
+  Exposure_min,
+
+  # description:
+  # maximum exposure in mAs across all instances in the series,
+  # derived from DICOM Exposure attribute;
+  # equals Exposure_min for fixed-exposure acquisitions;
+  # higher than Exposure_min for dose-modulated acquisitions (MAX across all instances)
+  Exposure_max,
+
+  # description:
+  # minimum duration of the X-ray exposure in ms across all instances in the series,
+  # derived from DICOM ExposureTime attribute (MIN across all instances)
+  ExposureTime_min,
+
+  # description:
+  # maximum duration of the X-ray exposure in ms across all instances in the series,
+  # derived from DICOM ExposureTime attribute (MAX across all instances)
+  ExposureTime_max,
+
+  # description:
+  # diameter of the region over which data were collected in mm as defined in
+  # DICOM DataCollectionDiameter attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  DataCollectionDiameter,
+
+  # description:
+  # diameter of the reconstruction field of view in mm as defined in
+  # DICOM ReconstructionDiameter attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  ReconstructionDiameter,
+
+  # description:
+  # ratio of the beam pitch for helical CT as defined in DICOM SpiralPitchFactor attribute;
+  # NULL for non-helical (sequential/axial) acquisitions;
+  # constant across instances — aggregated with ANY_VALUE
+  SpiralPitchFactor
+
+FROM ct_data
+-- Sort by low-cardinality acquisition parameters first to improve parquet compression
+ORDER BY
+  KVP NULLS LAST,
+  ConvolutionKernel[SAFE_OFFSET(0)] NULLS LAST,
+  SliceThickness NULLS LAST,
+  SeriesInstanceUID

--- a/assets/mr_index.sql
+++ b/assets/mr_index.sql
@@ -1,0 +1,175 @@
+# table-description:
+# This table contains one row per MR Image Storage (SOPClassUID 1.2.840.10008.5.1.4.1.1.4)
+# DICOM series in IDC, capturing MR acquisition and sequence parameters
+# that are not included in the main idc_index table.
+# The index can be joined to idc_index on SeriesInstanceUID to combine
+# universal series metadata with MR-specific acquisition parameters.
+# EchoTime and DiffusionBValue are reported as arrays of all distinct per-instance values
+# because they legitimately differ across instances within multi-echo and
+# diffusion-weighted series respectively.
+# All other attributes are aggregated with ANY_VALUE (one representative instance).
+
+WITH mr_data AS (
+  SELECT
+    SeriesInstanceUID,
+    ANY_VALUE(SAFE_CAST(MagneticFieldStrength AS FLOAT64)) AS MagneticFieldStrength,
+    ANY_VALUE(ScanningSequence) AS ScanningSequence,
+    ANY_VALUE(SequenceVariant) AS SequenceVariant,
+    ANY_VALUE(MRAcquisitionType) AS MRAcquisitionType,
+    ARRAY_AGG(DISTINCT SAFE_CAST(EchoTime AS FLOAT64) IGNORE NULLS
+              ORDER BY SAFE_CAST(EchoTime AS FLOAT64)) AS EchoTime,
+    ANY_VALUE(SAFE_CAST(RepetitionTime AS FLOAT64)) AS RepetitionTime,
+    ANY_VALUE(SAFE_CAST(EchoTrainLength AS INT64)) AS EchoTrainLength,
+    ANY_VALUE(SAFE_CAST(FlipAngle AS FLOAT64)) AS FlipAngle,
+    ANY_VALUE(SAFE_CAST(PixelBandwidth AS FLOAT64)) AS PixelBandwidth,
+    ANY_VALUE(SAFE_CAST(ImagingFrequency AS FLOAT64)) AS ImagingFrequency,
+    ANY_VALUE(ImagedNucleus) AS ImagedNucleus,
+    ANY_VALUE(SAFE_CAST(PixelSpacing[SAFE_OFFSET(0)] AS FLOAT64)) AS PixelSpacing_row_mm,
+    ANY_VALUE(SAFE_CAST(PixelSpacing[SAFE_OFFSET(1)] AS FLOAT64)) AS PixelSpacing_col_mm,
+    ANY_VALUE(`Rows`) AS `Rows`,
+    ANY_VALUE(`Columns`) AS `Columns`,
+    ANY_VALUE(SAFE_CAST(SliceThickness AS FLOAT64)) AS SliceThickness,
+    ANY_VALUE(SAFE_CAST(InversionTime AS FLOAT64)) AS InversionTime,
+    ANY_VALUE(ReceiveCoilName) AS ReceiveCoilName,
+    ANY_VALUE(SequenceName) AS SequenceName,
+    ARRAY_AGG(DISTINCT DiffusionBValue IGNORE NULLS
+              ORDER BY DiffusionBValue) AS DiffusionBValue,
+    ANY_VALUE(SAFE_CAST(NumberOfTemporalPositions AS INT64)) AS NumberOfTemporalPositions
+  FROM `bigquery-public-data.idc_v24.dicom_all`
+  WHERE SOPClassUID = '1.2.840.10008.5.1.4.1.1.4'
+  GROUP BY SeriesInstanceUID
+)
+SELECT
+  # description:
+  # DICOM SeriesInstanceUID — unique identifier of the MR series; use to join with idc_index
+  SeriesInstanceUID,
+
+  # description:
+  # static magnetic field strength in Tesla as defined in DICOM MagneticFieldStrength attribute;
+  # constant across instances within a series — aggregated with ANY_VALUE
+  MagneticFieldStrength,
+
+  # description:
+  # pulse sequence type as defined in DICOM ScanningSequence attribute
+  # (SE = Spin Echo, GR = Gradient Recalled, IR = Inversion Recovery, EP = Echo Planar);
+  # may contain multiple values; constant across instances — aggregated with ANY_VALUE
+  ScanningSequence,
+
+  # description:
+  # variant of the scanning sequence as defined in DICOM SequenceVariant attribute
+  # (SK = Segmented k-Space, MTC = Magnetization Transfer Contrast, SS = Steady State,
+  # TRSS = Time Reversed Steady State, SP = Spoiled, MP = MAG Prepared, OSP = Oversampling
+  # Phase, NONE = No sequence variant);
+  # may contain multiple values; constant across instances — aggregated with ANY_VALUE
+  SequenceVariant,
+
+  # description:
+  # whether the acquisition is 2D or 3D as defined in DICOM MRAcquisitionType attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  MRAcquisitionType,
+
+  # description:
+  # distinct echo times in ms present in the series, derived from DICOM EchoTime attribute;
+  # aggregated as ARRAY_AGG(DISTINCT) across all instances because EchoTime legitimately
+  # varies in multi-echo sequences; single-element array for single-echo series,
+  # multi-element array for multi-echo series (e.g., [2.46, 4.92, 7.38])
+  EchoTime,
+
+  # description:
+  # repetition time in ms as defined in DICOM RepetitionTime attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  RepetitionTime,
+
+  # description:
+  # number of echoes in the echo train as defined in DICOM EchoTrainLength attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  EchoTrainLength,
+
+  # description:
+  # flip angle in degrees as defined in DICOM FlipAngle attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  FlipAngle,
+
+  # description:
+  # receiver bandwidth per pixel in Hz as defined in DICOM PixelBandwidth attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelBandwidth,
+
+  # description:
+  # Larmor resonance frequency in MHz as defined in DICOM ImagingFrequency attribute;
+  # proportional to MagneticFieldStrength (42.577 MHz/T for proton);
+  # constant across instances — aggregated with ANY_VALUE
+  ImagingFrequency,
+
+  # description:
+  # nucleus used for imaging as defined in DICOM ImagedNucleus attribute
+  # (e.g., 1H for proton, 31P, 23Na);
+  # constant across instances — aggregated with ANY_VALUE
+  ImagedNucleus,
+
+  # description:
+  # in-plane pixel spacing along the row direction in mm, derived from DICOM PixelSpacing[0];
+  # MR pixel spacing is isotropic in almost all series in IDC;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelSpacing_row_mm,
+
+  # description:
+  # in-plane pixel spacing along the column direction in mm, derived from DICOM PixelSpacing[1];
+  # MR pixel spacing is isotropic in almost all series in IDC;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelSpacing_col_mm,
+
+  # description:
+  # number of pixel rows per image slice as defined in DICOM Rows attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  `Rows`,
+
+  # description:
+  # number of pixel columns per image slice as defined in DICOM Columns attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  `Columns`,
+
+  # description:
+  # nominal slice thickness in mm as defined in DICOM SliceThickness attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  SliceThickness,
+
+  # description:
+  # inversion time in ms as defined in DICOM InversionTime attribute;
+  # populated only for inversion recovery sequences, NULL otherwise;
+  # constant across instances — aggregated with ANY_VALUE
+  InversionTime,
+
+  # description:
+  # name of the receiver coil used as defined in DICOM ReceiveCoilName attribute;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  ReceiveCoilName,
+
+  # description:
+  # manufacturer-specific pulse sequence name as defined in DICOM SequenceName attribute
+  # (e.g., *tfl* for Siemens FLASH, *ep_b1000* for Siemens EPI diffusion);
+  # aggregated with ANY_VALUE — constant across instances within a series
+  SequenceName,
+
+  # description:
+  # distinct diffusion b-values in s/mm² present in the series,
+  # derived from DICOM DiffusionBValue attribute;
+  # aggregated as ARRAY_AGG(DISTINCT) across all instances because DiffusionBValue legitimately
+  # varies across instances in diffusion-weighted series;
+  # empty array for non-DWI series; multi-element for DWI (e.g., [0.0, 1000.0])
+  DiffusionBValue,
+
+  # description:
+  # number of temporal positions (time frames) in the series as defined in
+  # DICOM NumberOfTemporalPositions attribute; populated for dynamic (DCE-MRI) series;
+  # NULL otherwise; constant across instances — aggregated with ANY_VALUE
+  NumberOfTemporalPositions
+
+FROM mr_data
+-- Sort by low-cardinality acquisition parameters first to improve parquet compression
+ORDER BY
+  MagneticFieldStrength NULLS LAST,
+  ScanningSequence[SAFE_OFFSET(0)] NULLS LAST,
+  MRAcquisitionType NULLS LAST,
+  EchoTime[SAFE_OFFSET(0)] NULLS LAST,
+  SeriesInstanceUID

--- a/assets/pt_index.sql
+++ b/assets/pt_index.sql
@@ -1,0 +1,172 @@
+# table-description:
+# This table contains one row per Positron Emission Tomography Image Storage
+# (SOPClassUID 1.2.840.10008.5.1.4.1.1.128) DICOM series in IDC, capturing
+# PET acquisition, reconstruction and radiopharmaceutical parameters
+# that are not included in the main idc_index table.
+# The index can be joined to idc_index on SeriesInstanceUID to combine
+# universal series metadata with PET-specific acquisition parameters.
+# ActualFrameDuration is reported as an array of all distinct per-instance values
+# because it legitimately varies across frames in dynamic (multi-frame) PET acquisitions.
+# All other attributes are constant within a series and are aggregated with ANY_VALUE.
+
+WITH pt_data AS (
+  SELECT
+    SeriesInstanceUID,
+    ANY_VALUE(ARRAY_TO_STRING(SeriesType, '/')) AS SeriesType,
+    ANY_VALUE(Units) AS Units,
+    ANY_VALUE(DecayCorrection) AS DecayCorrection,
+    ANY_VALUE(CorrectedImage) AS CorrectedImage,
+    ANY_VALUE(RandomsCorrectionMethod) AS RandomsCorrectionMethod,
+    ANY_VALUE(ReconstructionMethod) AS ReconstructionMethod,
+    ARRAY_AGG(DISTINCT SAFE_CAST(ActualFrameDuration AS FLOAT64) IGNORE NULLS
+              ORDER BY SAFE_CAST(ActualFrameDuration AS FLOAT64)) AS ActualFrameDuration,
+    ANY_VALUE(ScatterCorrectionMethod) AS ScatterCorrectionMethod,
+    ANY_VALUE(AttenuationCorrectionMethod) AS AttenuationCorrectionMethod,
+    ANY_VALUE(RadiopharmaceuticalInformationSequence[SAFE_OFFSET(0)].RadionuclideCodeSequence[SAFE_OFFSET(0)].CodeMeaning) AS RadionuclideCodeMeaning,
+    ANY_VALUE(SAFE_CAST(RadiopharmaceuticalInformationSequence[SAFE_OFFSET(0)].RadionuclideTotalDose AS FLOAT64)) AS RadionuclideTotalDose,
+    CAST(ANY_VALUE(RadiopharmaceuticalInformationSequence[SAFE_OFFSET(0)].RadiopharmaceuticalStartTime) AS STRING) AS RadiopharmaceuticalStartTime,
+    ANY_VALUE(RadiopharmaceuticalInformationSequence[SAFE_OFFSET(0)].Radiopharmaceutical) AS Radiopharmaceutical,
+    ANY_VALUE(SAFE_CAST(PixelSpacing[SAFE_OFFSET(0)] AS FLOAT64)) AS PixelSpacing_row_mm,
+    ANY_VALUE(SAFE_CAST(PixelSpacing[SAFE_OFFSET(1)] AS FLOAT64)) AS PixelSpacing_col_mm,
+    ANY_VALUE(`Rows`) AS `Rows`,
+    ANY_VALUE(`Columns`) AS `Columns`,
+    ANY_VALUE(SAFE_CAST(SliceThickness AS FLOAT64)) AS SliceThickness,
+    ANY_VALUE(NumberOfSlices) AS NumberOfSlices,
+    ANY_VALUE(NumberOfTimeSlices) AS NumberOfTimeSlices
+  FROM `bigquery-public-data.idc_v24.dicom_all`
+  WHERE SOPClassUID = '1.2.840.10008.5.1.4.1.1.128'
+  GROUP BY SeriesInstanceUID
+)
+SELECT
+  # description:
+  # DICOM SeriesInstanceUID — unique identifier of the PET series; use to join with idc_index
+  SeriesInstanceUID,
+
+  # description:
+  # acquisition type of the series as defined in DICOM SeriesType attribute,
+  # encoded as a slash-separated string of the two type values
+  # (e.g., STATIC/IMAGE, DYNAMIC/IMAGE, GATED/IMAGE, WHOLE BODY/IMAGE);
+  # constant across instances — aggregated with ANY_VALUE(ARRAY_TO_STRING(SeriesType, '/'))
+  SeriesType,
+
+  # description:
+  # pixel value units as defined in DICOM Units attribute
+  # (e.g., BQML = Bq/mL, CNTS = counts, CPS = counts/s, GML = g/mL);
+  # constant across instances — aggregated with ANY_VALUE
+  Units,
+
+  # description:
+  # type of decay correction applied as defined in DICOM DecayCorrection attribute
+  # (START = corrected to scan start time, ADMIN = corrected to radiopharmaceutical
+  # administration time, NONE = no correction);
+  # constant across instances — aggregated with ANY_VALUE
+  DecayCorrection,
+
+  # description:
+  # list of corrections applied to the image as defined in DICOM CorrectedImage attribute
+  # (e.g., ATTN = attenuation, SCAT = scatter, DECY = decay, RAN = randoms);
+  # may contain multiple values; constant across instances — aggregated with ANY_VALUE
+  CorrectedImage,
+
+  # description:
+  # method used for randoms correction as defined in DICOM RandomsCorrectionMethod attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  RandomsCorrectionMethod,
+
+  # description:
+  # reconstruction algorithm as defined in DICOM ReconstructionMethod attribute
+  # (e.g., OSEM, FBP);
+  # constant across instances — aggregated with ANY_VALUE
+  ReconstructionMethod,
+
+  # description:
+  # distinct actual frame durations in ms present in the series,
+  # derived from DICOM ActualFrameDuration attribute;
+  # aggregated as ARRAY_AGG(DISTINCT) across all instances because ActualFrameDuration
+  # legitimately varies across frames in dynamic PET acquisitions;
+  # single-element array for static PET, multi-element for dynamic PET with
+  # variable frame durations
+  ActualFrameDuration,
+
+  # description:
+  # scatter correction method as defined in DICOM ScatterCorrectionMethod attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  ScatterCorrectionMethod,
+
+  # description:
+  # attenuation correction method as defined in DICOM AttenuationCorrectionMethod attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  AttenuationCorrectionMethod,
+
+  # description:
+  # code meaning of the radionuclide used, from
+  # RadiopharmaceuticalInformationSequence[0].RadionuclideCodeSequence[0].CodeMeaning;
+  # (e.g., Fluorine F18, Gallium Ga-68);
+  # constant across instances — aggregated with ANY_VALUE
+  RadionuclideCodeMeaning,
+
+  # description:
+  # total administered dose of the radionuclide in Bq, from
+  # RadiopharmaceuticalInformationSequence[0].RadionuclideTotalDose;
+  # constant across instances — aggregated with ANY_VALUE
+  RadionuclideTotalDose,
+
+  # description:
+  # time of radiopharmaceutical administration (injection time), from
+  # RadiopharmaceuticalInformationSequence[0].RadiopharmaceuticalStartTime;
+  # stored as STRING (HH:MM:SS.FFFFFF) because DICOM TIME type is not supported
+  # in parquet output; constant across instances — aggregated with ANY_VALUE
+  RadiopharmaceuticalStartTime,
+
+  # description:
+  # free-text name of the radiopharmaceutical as defined in
+  # RadiopharmaceuticalInformationSequence[0].Radiopharmaceutical
+  # (e.g., Fluorodeoxyglucose F^18^); values are not standardized across sites;
+  # see RadionuclideCodeMeaning for a more consistent alternative;
+  # constant across instances — aggregated with ANY_VALUE
+  Radiopharmaceutical,
+
+  # description:
+  # in-plane pixel spacing along the row direction in mm, derived from DICOM PixelSpacing[0];
+  # PET pixel spacing is isotropic in almost all series in IDC;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelSpacing_row_mm,
+
+  # description:
+  # in-plane pixel spacing along the column direction in mm, derived from DICOM PixelSpacing[1];
+  # PET pixel spacing is isotropic in almost all series in IDC;
+  # aggregated with ANY_VALUE — constant across instances within a series
+  PixelSpacing_col_mm,
+
+  # description:
+  # number of pixel rows per image slice as defined in DICOM Rows attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  `Rows`,
+
+  # description:
+  # number of pixel columns per image slice as defined in DICOM Columns attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  `Columns`,
+
+  # description:
+  # nominal slice thickness in mm as defined in DICOM SliceThickness attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  SliceThickness,
+
+  # description:
+  # total number of slices in the series as defined in DICOM NumberOfSlices attribute;
+  # constant across instances — aggregated with ANY_VALUE
+  NumberOfSlices,
+
+  # description:
+  # number of time frames in the series as defined in DICOM NumberOfTimeSlices attribute;
+  # populated only for dynamic (multi-frame) PET series, NULL for static PET;
+  # constant across instances — aggregated with ANY_VALUE
+  NumberOfTimeSlices
+
+FROM pt_data
+-- Sort by low-cardinality acquisition parameters first to improve parquet compression
+ORDER BY
+  Units NULLS LAST,
+  RadionuclideCodeMeaning NULLS LAST,
+  SeriesInstanceUID

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -29,6 +29,9 @@ class IDCBuildHook(BuildHookInterface):
         "tcia_idc_subset.parquet",
         "volume_geometry_index.parquet",
         "rtstruct_index.parquet",
+        "ct_index.parquet",
+        "mr_index.parquet",
+        "pt_index.parquet",
     }
 
     def _prune_excluded_parquet_files(self) -> None:

--- a/src/idc_index_data/__init__.py
+++ b/src/idc_index_data/__init__.py
@@ -95,6 +95,9 @@ _ALL_INDICES = [
     "volume_geometry_index",
     "rtstruct_index",
     "version_metadata_index",
+    "ct_index",
+    "mr_index",
+    "pt_index",
 ]
 
 INDEX_METADATA: dict[str, dict[str, Path | dict[str, object] | str | None]] = {}


### PR DESCRIPTION
Each index captures series-level DICOM attributes not included in idc_index. Attributes were selected and validated for coverage (>80% non-null) and within-series consistency. Dose-modulated CT attributes (XRayTubeCurrent, Exposure, ExposureTime) are stored as min/max pairs; multi-valued attributes (EchoTime, DiffusionBValue, ActualFrameDuration) are stored as ARRAY_AGG(DISTINCT) to capture per-instance variation in multi-echo MR, DWI, and dynamic PET series.