### PR TITLE
enh: add parquet provenance — version metadata and SHA256 checksums

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,6 +68,12 @@ jobs:
             release_artifacts/idc_index.parquet \
             -o release_artifacts/tcia_idc_subset.parquet
 
+      - name: Add provenance metadata and SHA256 checksums
+        run: |
+          python scripts/python/add_parquet_provenance.py \
+            release_artifacts/ \
+            --version "$(git describe --tags --long)"
+
       - name: Report generated index sizes
         run:
           python scripts/python/report_index_sizes.py release_artifacts | tee -a
@@ -145,7 +151,7 @@ jobs:
       - name: Attach artifacts to release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "release_artifacts/*.parquet,release_artifacts/*.json,release_artifacts/*.sql"
+          artifacts: "release_artifacts/*.parquet,release_artifacts/*.json,release_artifacts/*.sql,release_artifacts/*.sha256"
           allowUpdates: true
           omitBodyDuringUpdate: true
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ For example:
 Replace `current` with a specific version tag (e.g. `23.5.0`) to pin to a
 particular release.
 
+### Integrity verification
+
+Each parquet file is accompanied by a SHA256 checksum sidecar
+(`<name>.parquet.sha256`) published alongside it. Use it to verify a downloaded
+file:
+
+```bash
+curl -O https://storage.googleapis.com/idc-index-data-artifacts/current/release_artifacts/idc_index.parquet
+curl -O https://storage.googleapis.com/idc-index-data-artifacts/current/release_artifacts/idc_index.parquet.sha256
+sha256sum -c idc_index.parquet.sha256
+```
+
+Every parquet file also embeds the `idc-index-data` package version that
+generated it as Apache Parquet schema metadata under the key
+`idc_index_data_version`:
+
+```python
+import pyarrow.parquet as pq
+
+meta = pq.read_metadata("idc_index.parquet")
+print(meta.metadata[b"idc_index_data_version"])
+```
+
 ## Usage
 
 This package is intended to be used by the

--- a/scripts/python/add_parquet_provenance.py
+++ b/scripts/python/add_parquet_provenance.py
@@ -1,0 +1,41 @@
+"""Add provenance to parquet files: version in schema metadata + SHA256 sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+
+def add_version_metadata(path: Path, version: str) -> None:
+    table = pq.read_table(str(path))
+    existing = table.schema.metadata or {}
+    table = table.replace_schema_metadata(
+        {**existing, b"idc_index_data_version": version.encode()}
+    )
+    pq.write_table(table, str(path), compression="zstd")
+
+
+def write_sha256(path: Path) -> None:
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    (path.parent / (path.name + ".sha256")).write_text(f"{digest}  {path.name}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Embed version metadata and write SHA256 sidecars for parquet files."
+    )
+    parser.add_argument(
+        "directory", type=Path, help="Directory containing parquet files"
+    )
+    parser.add_argument(
+        "--version", required=True, help="idc-index-data version string to embed"
+    )
+    args = parser.parse_args()
+
+    for parquet_file in sorted(args.directory.glob("*.parquet")):
+        add_version_metadata(parquet_file, args.version)
+        write_sha256(parquet_file)
+        print(f"Processed: {parquet_file.name}")


### PR DESCRIPTION
Each parquet file now embeds the idc-index-data version in its Apache Parquet schema metadata (key: idc_index_data_version). A SHA256 sidecar (<name>.parquet.sha256) is also generated and published alongside every parquet in GCS and GitHub Releases to enable integrity verification.

Resolves #147 and #148