### PR TITLE
ci: fix mypy failures from numpy 2.3+ stubs and typed requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,15 @@ disallow_incomplete_defs = true
 module = "idc_index_data._version"
 ignore_missing_imports = true
 
+# numpy>=2.3 ships PEP 695 `type` statements in its bundled stubs, which mypy
+# refuses to parse while type-checking against python_version 3.10. We don't
+# rely on numpy types directly (it is only pulled in transitively), so skip
+# following its stubs rather than pinning numpy back or raising python_version.
+[[tool.mypy.overrides]]
+module = "numpy.*"
+follow_imports = "skip"
+follow_imports_for_stubs = true
+
 
 [tool.ruff]
 src = ["src", "scripts"]

--- a/tests/test_gcs_cors.py
+++ b/tests/test_gcs_cors.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import io
 
 import pytest
-import requests  # type: ignore[import-untyped]
+import requests
 
 GCS_BASE = (
     "https://storage.googleapis.com/idc-index-data-artifacts/current/release_artifacts"


### PR DESCRIPTION
## Problem

CI has been red on recent PRs (e.g. #153) due to two latent mypy failures that surface only on current dependency versions — they are unrelated to the changes in those PRs. `main` itself last ran CI on 2026-05-11, before these dependency releases.

1. **numpy ≥2.3 stubs** ship PEP 695 `type` statements. mypy refuses to parse them while type-checking against `python_version = "3.10"`:

   ```
   numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
   ```

   This reproduces even on the latest mypy (2.1.0), so it is not fixed by bumping mypy.

2. **requests 2.34.2** now ships `py.typed`, so the `# type: ignore[import-untyped]` in `tests/test_gcs_cors.py` is an unused-ignore error under `strict`.

## Fix

- Add a `numpy.*` mypy override with `follow_imports = "skip"`. This keeps numpy **current** and keeps `python_version` at **3.10** (so the project's own code is still checked against the version it ships for). numpy is only a transitive dependency and we don't type against it directly, so skipping its stubs costs nothing here.
- Remove the obsolete `# type: ignore[import-untyped]` on the `requests` import.

Considered and rejected: pinning `numpy<2.3` (dependabot would keep re-breaking it; stale stubs) and raising mypy's `python_version` to 3.12 (would stop catching 3.10/3.11-incompatible syntax in our own code).

Verified locally with `pre-commit run mypy --all-files` → Passed, against numpy 2.5.0 and requests 2.34.2.

Once this merges, `@dependabot rebase` on #153 will clear its CI (its CD "Generate index artifacts" job fails only because dependabot PRs run without GCP secrets — that is expected and passes on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)