### PR TITLE
docs: clarify BodyPartExamined for derived (SEG/RTSTRUCT) series

### DIFF
--- a/scripts/sql/idc_index.sql
+++ b/scripts/sql/idc_index.sql
@@ -49,7 +49,10 @@ SELECT
   # textual description of the study content (DICOM attribute)
   ANY_VALUE(StudyDescription) AS StudyDescription,
   # description:
-  # body part imaged (not applicable for SM series) (DICOM attribute)
+  # body part imaged (not applicable for SM series) (DICOM attribute). For derived
+  # series (SEG, RTSTRUCT) this reflects the source acquisition, not the segmented
+  # anatomy -- what was segmented is recorded in the seg_index table
+  # (SegmentedPropertyType_CodeMeanings) and in rtstruct_index.
   ANY_VALUE(dicom_curated.BodyPartExamined) AS BodyPartExamined,
   # series level attributes
   # description:


### PR DESCRIPTION
## What

Extend the `idc_index.BodyPartExamined` column description to clarify what it means for **derived** series.

Before:
> body part imaged (not applicable for SM series) (DICOM attribute)

After:
> body part imaged (not applicable for SM series) (DICOM attribute). For derived series (SEG, RTSTRUCT) this reflects the source acquisition, not the segmented anatomy -- what was segmented is recorded in the seg_index table (SegmentedPropertyType_CodeMeanings) and in rtstruct_index.

## Why

`BodyPartExamined` is carried over from the source acquisition, so for SEG/RTSTRUCT series it describes the imaged region of the *source image*, not the anatomy that was actually segmented. Users (and LLM agents) routinely misread it as "segmented anatomy" and filter on it incorrectly. The added sentence points them to where the segmented anatomy really lives (`seg_index.SegmentedPropertyType_CodeMeanings`, `rtstruct_index`).

The wording is deliberately neutral — no downstream API/tool names — so it reads correctly for idc-index Python users and BigQuery consumers alike.

## How

Edits the `# description:` comment block above `BodyPartExamined` in `scripts/sql/idc_index.sql`; the multi-line comment is joined by the existing description parser (verified locally). No query logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)