### PR TITLE
docs: clarify BodyPartExamined for derived (SEG/RTSTRUCT) series

### DIFF
--- a/scripts/sql/idc_index.sql
+++ b/scripts/sql/idc_index.sql
@@ -49,7 +49,10 @@ SELECT
   # textual description of the study content (DICOM attribute)
   ANY_VALUE(StudyDescription) AS StudyDescription,
   # description:
-  # body part imaged (not applicable for SM series) (DICOM attribute)
+  # body part imaged (not applicable for SM series) (DICOM attribute). For derived
+  # series (SEG, RTSTRUCT) this reflects the source acquisition, not the segmented
+  # anatomy -- what was segmented is recorded in the seg_index table
+  # (SegmentedPropertyType_CodeMeanings) and in rtstruct_index.
   ANY_VALUE(dicom_curated.BodyPartExamined) AS BodyPartExamined,
   # series level attributes
   # description:


### PR DESCRIPTION
BodyPartExamined reflects the source acquisition's imaged region, which for derived series (SEG, RTSTRUCT) is not the segmented anatomy. Point readers to where the segmented anatomy actually lives: seg_index (SegmentedPropertyType_CodeMeanings) and rtstruct_index.

Wording is neutral (no downstream API/tool names) so it reads correctly for both idc-index Python users and BigQuery consumers.

replaces #156 that used foreign branch