### PR TITLE
enh: add PhotometricInterpretation and PixelRepresentation to idc_index

### DIFF
--- a/scripts/sql/idc_index.sql
+++ b/scripts/sql/idc_index.sql
@@ -139,6 +139,17 @@ SELECT
     ELSE ERROR(CONCAT("Unmapped TransferSyntaxUID: ", TransferSyntaxUID, ". Please add a mapping."))
   END) AS transfer_syntax_name,
   # description:
+  # intended interpretation of the pixel data, e.g., MONOCHROME2 (grayscale),
+  # RGB or YBR_FULL_422 (color); NULL for non-image objects (e.g., SEG, SR,
+  # RTSTRUCT); comma-separated when a series contains instances with different
+  # values (DICOM attribute)
+  STRING_AGG(DISTINCT PhotometricInterpretation, "," ORDER BY PhotometricInterpretation) AS PhotometricInterpretation,
+  # description:
+  # data representation of pixel sample values: "0" for unsigned integers, "1"
+  # for signed integers; NULL for non-image objects; comma-separated when a
+  # series contains instances with different values (DICOM attribute)
+  STRING_AGG(DISTINCT CAST(PixelRepresentation AS STRING), "," ORDER BY CAST(PixelRepresentation AS STRING)) AS PixelRepresentation,
+  # description:
   # manufacturer of the equipment that produced the series (DICOM attribute)
   ANY_VALUE(Manufacturer) AS Manufacturer,
   # description:


### PR DESCRIPTION
## Summary

Adds two pixel-encoding descriptors to the main series-level index (`scripts/sql/idc_index.sql`):

- **`PhotometricInterpretation`** — how to interpret the pixel data (e.g. `MONOCHROME2` grayscale, `RGB`/`YBR_FULL_422` color)
- **`PixelRepresentation`** — pixel sample representation, `0` = unsigned / `1` = signed integers

Both are aggregated with `STRING_AGG(DISTINCT …)` rather than `ANY_VALUE`, matching the existing `TransferSyntaxUID` handling, so the small fraction of series whose instances carry mixed values is represented instead of silently collapsed to one arbitrary value.

## Why

`PhotometricInterpretation` was not present in any index. Together with `PixelRepresentation` it lets consumers reason about grayscale vs. color and signed vs. unsigned pixels directly from the main index. Before adding, I swept the source table for other broadly-useful, cheap, series-level attributes and measured each candidate's real compressed cost — see the added `main_index_attribute_recommendations.md`.

## Measured impact (v24, 1,032,911 series)

| Attribute | % series present | Mixed within series | Added ZSTD size |
| --- | ---: | ---: | ---: |
| `PhotometricInterpretation` | 71% | 7,471 (0.7%) | ~91 KB |
| `PixelRepresentation` | 70.7% | 288 (0.03%) | ~136 KB |

~227 KB combined (~0.3% of the ~81 MB bundled parquet), well within the PyPI 100 MB per-file limit. The ~29% NULL rate is expected — non-image objects (SEG, SR, RTSTRUCT, PR, registration).

Other candidates (`SamplesPerPixel`, `BitsAllocated`, `ImageType`, `gcs_bucket`, `FrameOfReferenceUID`, …) are documented with sizes and left for a future pass; `FrameOfReferenceUID` in particular (~5–8 MB) was deliberately deferred as too heavy for the bundled index.

## Validation

- `bq query --dry_run` passes on the modified SQL
- Build's SQL-comment parser extracts descriptions for both new columns
- `pre-commit` clean on changed files

Parquet/schema regeneration happens in CI on merge; no local artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)